### PR TITLE
docs: add global installation command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,27 @@ Following Claude Code's philosophy, CCManager keeps things minimal and intuitive
 ## Install
 
 ```bash
-$ npm install
-$ npm run build
-$ npm start
+npm install -g ccmanager
+```
+
+Or for local development:
+
+```bash
+npm install
+npm run build
+npm start
 ```
 
 ## Usage
 
 ```bash
-$ npx ccmanager
+ccmanager
+```
+
+Or run without installing:
+
+```bash
+npx ccmanager
 ```
 
 ## Keyboard Shortcuts


### PR DESCRIPTION
## Summary
- Add `npm install -g ccmanager` command to README install section
- Simplify installation section while keeping local development instructions
- Address issue #49 by providing clear global installation method

## Changes
- Updated README.md install section with global installation command
- Reorganized installation instructions for better clarity
- Maintained existing local development setup instructions

## Related Issues
Closes #49

## Test Plan
- [x] Verify README.md renders correctly
- [x] Ensure installation instructions are clear and accessible
- [x] Confirm both global and local installation methods are documented